### PR TITLE
adds permissions middleware

### DIFF
--- a/server/permit.js
+++ b/server/permit.js
@@ -1,0 +1,19 @@
+// middleware for doing role-based permissions
+//expects allowed user roles as params and returns a middleware which will either
+//pass to the next middleware or send a 403 based on the user role
+export default function permit(...allowed) {
+  const isAllowed = role => allowed.indexOf(role) > -1
+
+  // return a middleware
+  return (req, res, next) => {
+    let userRole
+    if (req.user.isAdmin) userRole = 'Admin'
+    else if (req.user) userRole = 'Auth_User'
+    else userRole = 'Unauth_User'
+    if (req.user && isAllowed(userRole)) next()
+    else {
+      // role is allowed, so continue on the next middleware
+      res.status(403).json({message: 'Forbidden'}) // user is forbidden
+    }
+  }
+}

--- a/server/permit.js
+++ b/server/permit.js
@@ -1,7 +1,7 @@
 // middleware for doing role-based permissions
 //expects allowed user roles as params and returns a middleware which will either
 //pass to the next middleware or send a 403 based on the user role
-export default function permit(...allowed) {
+const permit = (...allowed) => {
   const isAllowed = role => allowed.indexOf(role) > -1
 
   // return a middleware
@@ -17,3 +17,5 @@ export default function permit(...allowed) {
     }
   }
 }
+
+module.exports = permit

--- a/server/permit.js
+++ b/server/permit.js
@@ -7,9 +7,9 @@ const permit = (...allowed) => {
   // return a middleware
   return (req, res, next) => {
     let userRole
-    if (req.user.isAdmin) userRole = 'Admin'
-    else if (req.user) userRole = 'Auth_User'
-    else userRole = 'Unauth_User'
+    if (!req.user) userRole = 'Unauth_User'
+    else if (req.user.isAdmin) userRole = 'Admin'
+    else userRole = 'Auth_User'
     if (req.user && isAllowed(userRole)) next()
     else {
       // role is allowed, so continue on the next middleware


### PR DESCRIPTION
To test - plug middleware into a route where we want to restrict access. For instance, if we wanted to restrict get requests to /api/products to only allow admins, we would modify the route to look like the following:

`const permit = require('../permit')
router.get('/products',permit('Admin'), (req,res,next)=>{
//normal get products stuff
})
`

Try accessing the route as an unauthenticated user as well as an authenticated non-admin user. We expect a 403 response. When we log in as an admin, we expect the content to be served as normal.
